### PR TITLE
Finagle gcd and lcm to satisfy a multiplicative identity

### DIFF
--- a/src/__tests__/fraction-rawify.spec.ts
+++ b/src/__tests__/fraction-rawify.spec.ts
@@ -989,14 +989,14 @@ const tests = [
     set: -3,
     fn: 'lcm',
     param: 3,
-    expect: '3',
+    expect: '-3', // Deviates from rawify's convention
   },
   {
     label: 'lcm(3,-3)',
     set: 3,
     fn: 'lcm',
     param: -3,
-    expect: '3',
+    expect: '-3', // Deviates from rawify's convention
   },
   {
     label: 'lcm(0,3)',


### PR DESCRIPTION
Replicate something similar for radical/radicand analogues. Extend gcd, lcm and mmod to bigints.
Fix zero fraction normalization.

ref #27